### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
This will make the "languages" displayed on Github ignore the jupyter notebook demos. This way, people searching know it's a c++/Python code base and not 97% Jupyter.